### PR TITLE
add a trailing slash to tags url

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,7 @@
       {{ with .Params.tags }}
         <ul class="tags">
         {{ range . }}
-          <li> <a href="{{ "tags" | absURL }}{{ . | urlize }}">{{ . }}</a> </li>
+          <li> <a href="{{ "tags/" | absURL }}{{ . | urlize }}">{{ . }}</a> </li>
         {{ end }}
         </ul>
       {{ end }}


### PR DESCRIPTION
When creating the URL for the tags, it's missing a slash after the "tags" word.
From the template docs https://gohugo.io/functions/absurl/#readout
absURL and relURL are smart about missing slashes, but they will not add a closing slash to a URL if it is not present.